### PR TITLE
Harden dashboard metadata sanitization and URL validation

### DIFF
--- a/SDMS-backend/src/utils/urlSanitize.js
+++ b/SDMS-backend/src/utils/urlSanitize.js
@@ -1,17 +1,29 @@
-const WRAPPER_TAG_RE = /<\/?WebsiteContent_[^>]*>/gi;
+const WRAPPER_TAG_RE = /^\s*<WebsiteContent_[^>]+>|<\/WebsiteContent_[^>]+>\s*$/gi;
+
+export function stripWebsiteContentTags(input) {
+  if (input == null) return '';
+  const original = String(input);
+  const cleaned = original.replace(WRAPPER_TAG_RE, '').trim();
+  if (cleaned !== original.trim()) {
+    console.info('[urlSanitize] WebsiteContent tags stripped', {
+      changed: true,
+      originalLength: original.length,
+      cleanedLength: cleaned.length
+    });
+  }
+  return cleaned;
+}
 
 export function stripWebsiteContentWrappers(input) {
-  if (input == null) return '';
-  return String(input).replace(WRAPPER_TAG_RE, '').trim();
+  return stripWebsiteContentTags(input);
 }
 
 export function toSafeHttpUrl(input) {
-  const cleaned = stripWebsiteContentWrappers(input);
+  const cleaned = stripWebsiteContentTags(input);
   if (!cleaned) return null;
   try {
     const url = new URL(cleaned);
-    if (!['http:', 'https:'].includes(url.protocol)) return null;
-    if (!url.hostname) return null;
+    if (!['http:', 'https:'].includes(url.protocol) || !url.hostname) return null;
     return url.toString();
   } catch {
     return null;
@@ -20,7 +32,7 @@ export function toSafeHttpUrl(input) {
 
 export function sanitizePageMetadata({ pageTitle, pageUrl } = {}) {
   return {
-    pageTitle: stripWebsiteContentWrappers(pageTitle),
+    pageTitle: stripWebsiteContentTags(pageTitle) || 'Untitled',
     pageUrl: toSafeHttpUrl(pageUrl)
   };
 }

--- a/SDMS-backend/test/dashboardSanitize.integration.test.js
+++ b/SDMS-backend/test/dashboardSanitize.integration.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+test('dashboard sanitize script cleans wrapped tab metadata for rendering', () => {
+  const script = fs.readFileSync(new URL('../../Student Discipline Management System/js/url_sanitize.js', import.meta.url), 'utf8');
+  const sandbox = { window: {}, console, URL };
+  vm.createContext(sandbox);
+  vm.runInContext(script, sandbox);
+
+  const sanitized = sandbox.window.SDMSUrlSanitize.sanitizePageMetadata({
+    pageTitle: '<WebsiteContent_title>  Student List  </WebsiteContent_title>',
+    pageUrl: '<WebsiteContent_url>https://sdms.local/student_list.html</WebsiteContent_url>'
+  });
+
+  assert.equal(sanitized.pageTitle, 'Student List');
+  assert.equal(sanitized.pageUrl, 'https://sdms.local/student_list.html');
+});

--- a/SDMS-backend/test/urlSanitize.test.js
+++ b/SDMS-backend/test/urlSanitize.test.js
@@ -1,24 +1,38 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { stripWebsiteContentWrappers, toSafeHttpUrl, sanitizePageMetadata } from '../src/utils/urlSanitize.js';
+import { stripWebsiteContentTags, stripWebsiteContentWrappers, toSafeHttpUrl, sanitizePageMetadata } from '../src/utils/urlSanitize.js';
 
-test('stripWebsiteContentWrappers removes WebsiteContent wrappers', () => {
+test('stripWebsiteContentTags removes WebsiteContent wrappers', () => {
   const input = '<WebsiteContent_abc>https://example.com/x</WebsiteContent_abc>';
-  assert.equal(stripWebsiteContentWrappers(input), 'https://example.com/x');
+  assert.equal(stripWebsiteContentTags(input), 'https://example.com/x');
 });
 
-test('toSafeHttpUrl accepts http/https only', () => {
+test('stripWebsiteContentWrappers remains backward compatible alias', () => {
+  const input = '<WebsiteContent_abc> Admin Dashboard </WebsiteContent_abc>';
+  assert.equal(stripWebsiteContentWrappers(input), 'Admin Dashboard');
+});
+
+test('toSafeHttpUrl accepts strict absolute http/https only', () => {
   assert.equal(toSafeHttpUrl('<WebsiteContent_x>https://example.com/path</WebsiteContent_x>'), 'https://example.com/path');
+  assert.equal(toSafeHttpUrl('http://example.com/path?q=1'), 'http://example.com/path?q=1');
+  assert.equal(toSafeHttpUrl('/relative/path'), null);
   assert.equal(toSafeHttpUrl('ftp://example.com/file'), null);
   assert.equal(toSafeHttpUrl('javascript:alert(1)'), null);
   assert.equal(toSafeHttpUrl('not-a-url'), null);
 });
 
-test('sanitizePageMetadata strips wrappers and validates URL', () => {
+test('sanitizePageMetadata strips wrappers, validates URL, and falls back title', () => {
   const out = sanitizePageMetadata({
     pageTitle: '<WebsiteContent_t> Admin Dashboard </WebsiteContent_t>',
     pageUrl: '<WebsiteContent_u>https://sdms.local/student_list.html</WebsiteContent_u>'
   });
   assert.equal(out.pageTitle, 'Admin Dashboard');
   assert.equal(out.pageUrl, 'https://sdms.local/student_list.html');
+
+  const invalid = sanitizePageMetadata({
+    pageTitle: '<WebsiteContent_t></WebsiteContent_t>',
+    pageUrl: '<WebsiteContent_u>javascript:alert(1)</WebsiteContent_u>'
+  });
+  assert.equal(invalid.pageTitle, 'Untitled');
+  assert.equal(invalid.pageUrl, null);
 });


### PR DESCRIPTION
### Motivation
- Incoming tab metadata contained literal `<WebsiteContent_...>` wrappers and malformed URLs which produced broken titles, invalid links, and request failures in the Admin Dashboard.
- A single, robust sanitizer and stricter URL validation are needed so UI rendering and network requests never consume raw/unsafe metadata.

### Description
- Added a centralized sanitizer `stripWebsiteContentTags` (kept `stripWebsiteContentWrappers` as an alias) and applied it in the frontend `js/url_sanitize.js` and backend `SDMS-backend/src/utils/urlSanitize.js`, including structured logs when wrappers are stripped.
- Tightened URL checks in `toSafeHttpUrl` to accept only absolute `http`/`https` URLs with non-empty hosts and updated behavior to return `null` for invalid URLs; titles now fall back to `Untitled` when empty after stripping.
- Hardened `Student Discipline Management System/js/dashboard.js` so `API_BASE` and request `path` are sanitized and validated before `fetch`, and made dashboard initialization non-blocking by catching and logging init errors.
- Added tests: expanded `SDMS-backend/test/urlSanitize.test.js` and added `SDMS-backend/test/dashboardSanitize.integration.test.js` which executes the frontend sanitizer in a VM to verify wrapped metadata is cleaned.

### Testing
- Ran `node --test SDMS-backend/test/urlSanitize.test.js SDMS-backend/test/dashboardSanitize.integration.test.js` and all tests passed (all subtests ok), validating wrapper stripping, strict URL validation, alias compatibility, title fallback, and the integration VM check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb7337a0c832084a7f9039dd35ba9)