### PR TITLE
Sanitize and validate batch student uploads; add chunking and per-row error reporting

### DIFF
--- a/SDMS-backend/src/utils/studentUpload.js
+++ b/SDMS-backend/src/utils/studentUpload.js
@@ -1,0 +1,73 @@
+import { stripWebsiteContentTags } from './urlSanitize.js';
+
+const STRICT_UPLOAD_SCHEMA = process.env.SDMS_STRICT_UPLOAD_SCHEMA === 'true';
+
+function sanitizeText(value) {
+  if (value == null) return null;
+  const cleaned = stripWebsiteContentTags(value);
+  return cleaned === '' ? null : cleaned;
+}
+
+export function normalizeStudentUploadRow(student = {}) {
+  const firstName = sanitizeText(student.first_name);
+  const middleName = sanitizeText(student.middle_name);
+  const lastName = sanitizeText(student.last_name);
+  const fallbackFullName = sanitizeText(student.full_name);
+  const fullName = [firstName, middleName, lastName].filter(Boolean).join(' ').trim() || fallbackFullName;
+
+  const ageRaw = student.age == null || student.age === '' ? null : Number(student.age);
+  return {
+    lrn: sanitizeText(student.lrn),
+    full_name: fullName,
+    grade: sanitizeText(student.grade),
+    section: sanitizeText(student.section),
+    strand: sanitizeText(student.strand),
+    age: Number.isFinite(ageRaw) ? ageRaw : null,
+    compat: {
+      ignored_last_name: Boolean(lastName && fallbackFullName),
+      strict_mode: STRICT_UPLOAD_SCHEMA
+    }
+  };
+}
+
+export function validateStudentUploadRow(student = {}, row = 1) {
+  const issues = [];
+  if (!student.full_name) issues.push({ row, field: 'full_name', error: 'required' });
+  if (student.lrn && !/^\d{1,12}$/.test(student.lrn)) issues.push({ row, field: 'lrn', error: 'invalid_format' });
+  if (student.age != null && (student.age < 0 || student.age > 120)) issues.push({ row, field: 'age', error: 'invalid_range' });
+  return issues;
+}
+
+export async function processBatchStudents(students = [], insertStudent) {
+  const results = { inserted: 0, skipped: 0, failed: 0, errors: [], details: [] };
+
+  for (let i = 0; i < students.length; i++) {
+    const row = i + 1;
+    const normalized = normalizeStudentUploadRow(students[i] ?? {});
+    const rowValidationErrors = validateStudentUploadRow(normalized, row);
+    if (rowValidationErrors.length) {
+      results.failed++;
+      results.errors.push(...rowValidationErrors);
+      results.details.push({ row, status: 'failed', lrn: normalized.lrn, reason: 'Validation failed' });
+      continue;
+    }
+
+    try {
+      const inserted = await insertStudent(normalized);
+      results.inserted++;
+      results.details.push({ row, status: 'inserted', lrn: normalized.lrn, id: inserted?.id ?? null });
+    } catch (e) {
+      if (e && e.code === '23505' && /lrn/i.test(e.detail || '')) {
+        results.skipped++;
+        results.errors.push({ row, field: 'lrn', error: 'duplicate' });
+        results.details.push({ row, status: 'skipped', lrn: normalized.lrn, reason: 'Duplicate LRN' });
+      } else {
+        results.failed++;
+        results.errors.push({ row, field: 'row', error: e.message });
+        results.details.push({ row, status: 'failed', lrn: normalized.lrn, reason: e.message });
+      }
+    }
+  }
+
+  return results;
+}

--- a/SDMS-backend/test/upload.integration.test.js
+++ b/SDMS-backend/test/upload.integration.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { processBatchStudents } from '../src/utils/studentUpload.js';
+
+test('processBatchStudents keeps valid rows and reports structured errors for invalid rows', async () => {
+  const rows = [
+    { lrn: '123456789012', full_name: 'Valid Student', grade: '11' },
+    { lrn: 'BAD-LRN', full_name: 'Invalid LRN' },
+    { lrn: '999', full_name: '' },
+    { lrn: '123456789012', full_name: 'Duplicate LRN' }
+  ];
+
+  const seen = new Set();
+  const result = await processBatchStudents(rows, async (student) => {
+    if (seen.has(student.lrn)) {
+      const error = new Error('duplicate key value violates unique constraint');
+      error.code = '23505';
+      error.detail = 'Key (lrn)=(123456789012) already exists.';
+      throw error;
+    }
+    seen.add(student.lrn);
+    return { id: seen.size };
+  });
+
+  assert.equal(result.inserted, 1);
+  assert.equal(result.skipped, 1);
+  assert.equal(result.failed, 2);
+  assert.deepEqual(result.errors, [
+    { row: 2, field: 'lrn', error: 'invalid_format' },
+    { row: 3, field: 'full_name', error: 'required' },
+    { row: 4, field: 'lrn', error: 'duplicate' }
+  ]);
+});

--- a/docs/examples/sanitized_students.csv
+++ b/docs/examples/sanitized_students.csv
@@ -1,0 +1,3 @@
+lrn,full_name,age,grade,section,strand
+123456789012,John Dela Cruz,16,11,A,STEM
+223456789012,Jane Q. Public,17,12,B,HUMSS

--- a/docs/examples/upload_error_response.json
+++ b/docs/examples/upload_error_response.json
@@ -1,0 +1,17 @@
+{
+  "inserted": 2,
+  "skipped": 1,
+  "failed": 2,
+  "errors": [
+    { "row": 2, "field": "lrn", "error": "invalid_format" },
+    { "row": 4, "field": "full_name", "error": "required" },
+    { "row": 5, "field": "lrn", "error": "duplicate" }
+  ],
+  "details": [
+    { "row": 1, "status": "inserted", "lrn": "123456789012", "id": 101 },
+    { "row": 2, "status": "failed", "lrn": "BAD-LRN", "reason": "Validation failed" },
+    { "row": 3, "status": "inserted", "lrn": "223456789012", "id": 102 },
+    { "row": 4, "status": "failed", "lrn": "333333333333", "reason": "Validation failed" },
+    { "row": 5, "status": "skipped", "lrn": "123456789012", "reason": "Duplicate LRN" }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Batch uploads were failing due to untrusted Edge tab metadata wrapped in `<WebsiteContent_...>` tags, schema/legacy-name mismatches, and scaling/timeouts for large CSVs.
- The change centralizes sanitization so both client and server strip wrapper tags and treat page content as untrusted before parsing/validation.
- The goal is to accept valid rows while returning structured, per-row errors for invalid rows and to improve large-file resilience.

### Description
- Frontend: updated `Student Discipline Management System/js/batch_upload.js` to strip `<WebsiteContent_...>` wrappers for every parsed cell, support quoted CSV values and legacy/aliased headers, map legacy name fields to `full_name`, run per-row validation in the UI, and upload in chunks (`BATCH_CHUNK_SIZE=200`) with progress updates.
- Backend: added `SDMS-backend/src/utils/studentUpload.js` with `normalizeStudentUploadRow`, `validateStudentUploadRow`, and `processBatchStudents` to centralize sanitization, legacy-name compatibility, validation rules, and non-atomic batch processing.
- API integration: `/api/students/batch` (in `SDMS-backend/src/routes/students.js`) now uses the batch processor, logs sanitized payloads on insert errors, and returns structured per-row error objects (`{ row, field, error }`) plus `details` for each input row.
- Tests & examples: added unit/integration tests (`SDMS-backend/test/studentUpload.test.js`, `SDMS-backend/test/upload.integration.test.js`) and example artifacts (`docs/examples/sanitized_students.csv`, `docs/examples/upload_error_response.json`).

### Testing
- Ran automated unit tests with `node --test SDMS-backend/test/urlSanitize.test.js SDMS-backend/test/studentUpload.test.js SDMS-backend/test/upload.integration.test.js`, and all tests passed (no failures).
- Performed static syntax checks with `node -c` on the modified frontend and backend modules, which succeeded.
- Attempted a Playwright screenshot of the running frontend at `http://localhost:3000/student_list.html`, but it failed because the local app was not serving that URL in this environment (`ERR_EMPTY_RESPONSE`); this does not affect the server-side unit/integration test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fbbb37658832093eb71e454e2186b)