### PR TITLE
Add CSV batch-upload endpoint for students

### DIFF
--- a/SDMS-backend/package.json
+++ b/SDMS-backend/package.json
@@ -13,9 +13,11 @@
   "dependencies": {
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
+    "csv-parser": "^3.2.0",
     "dotenv": "^16.6.1",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5-lts.1",
     "node-fetch": "^3.3.2",
     "nodemailer": "^6.9.14",
     "pg": "^8.11.5"


### PR DESCRIPTION
### Motivation
- Provide a convenient API to bulk import students from a CSV with headers `LRN, FullName, Age, Grade, Section, Strand`.
- Ensure imports are safe and id generation remains database-driven while skipping duplicate LRNs.

### Description
- Added `POST /api/students/batch-upload` in `SDMS-backend/src/routes/students.js` that accepts a multipart upload using `multer` memory storage with `upload.single('file')`.
- Parses the uploaded CSV via `csv-parser` (streamed from the uploaded buffer using `Readable.from`) and maps rows to `lrn, full_name, age, grade, section, strand`.
- Inserts rows using parameterized queries that omit the `id` column so Postgres generates the UUID, and uses `ON CONFLICT (lrn) DO NOTHING` to skip duplicates; counts inserted rows via `rowCount` and returns JSON `{ success: true, inserted }`.
- Adds `csv-parser` and `multer` to `SDMS-backend/package.json` as dependencies and includes robust error handling to return `500` on server errors.

### Testing
- Ran a static syntax check with `node --check SDMS-backend/src/routes/students.js`, which succeeded.
- Attempted to install runtime deps with `cd SDMS-backend && npm install multer csv-parser`, which failed due to registry access (`403 Forbidden`) in this environment, so runtime dependency verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe27b600c83209dac6af6a8d34e7a)