### PR TITLE
Add CSV batch-upload for students, UUID v4 ID validation, and required deps

### DIFF
--- a/SDMS-backend/package.json
+++ b/SDMS-backend/package.json
@@ -13,9 +13,11 @@
   "dependencies": {
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
+    "csv-parser": "^3.2.0",
     "dotenv": "^16.6.1",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5-lts.1",
     "node-fetch": "^3.3.2",
     "nodemailer": "^6.9.14",
     "pg": "^8.11.5"


### PR DESCRIPTION
### Motivation

- Provide a convenient CSV-based batch import for students and enforce stronger validation on student id parameters.

### Description

- Added `csv-parser` and `multer` dependencies and configured multer memory storage for multipart file uploads in `package.json` and `students` router.
- Implemented `/api/students/batch-upload` POST endpoint that parses an uploaded CSV file, maps columns (`LRN`, `FullName`, `Grade`, `Section`, `Strand`, `Age`), inserts rows with `on conflict (lrn) do nothing`, and returns an insert count.
- Added `UUID_V4_REGEX` and request validation for `/:id` routes (`GET`, `PUT`, `DELETE`) to return `400` on invalid id format and avoid unnecessary DB lookups.
- Kept create/update handlers aligned with the current schema by using `full_name` and removed references to legacy name fields; added basic age handling when importing CSV rows.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe27b600c83209dac6af6a8d34e7a)