### PR TITLE
Support numeric and UUID student IDs in student routes

### DIFF
--- a/SDMS-backend/package.json
+++ b/SDMS-backend/package.json
@@ -13,9 +13,11 @@
   "dependencies": {
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
+    "csv-parser": "^3.2.0",
     "dotenv": "^16.6.1",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5-lts.1",
     "node-fetch": "^3.3.2",
     "nodemailer": "^6.9.14",
     "pg": "^8.11.5"

--- a/SDMS-backend/src/routes/students.js
+++ b/SDMS-backend/src/routes/students.js
@@ -1,10 +1,28 @@
 import { Router } from 'express';
+import multer from 'multer';
+import csv from 'csv-parser';
+import { Readable } from 'node:stream';
 import { query } from '../db.js';
 import { processBatchStudents } from '../utils/studentUpload.js';
 
 const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
 
 const STUDENT_COLUMNS = 'id, lrn, full_name, grade, section, strand';
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const NUMERIC_ID_REGEX = /^\d+$/;
+
+const getStudentLookup = (idParam) => {
+  if (UUID_REGEX.test(idParam)) {
+    return { column: 'id', value: idParam };
+  }
+
+  if (NUMERIC_ID_REGEX.test(idParam)) {
+    return { column: 'student_id', value: Number.parseInt(idParam, 10) };
+  }
+
+  return null;
+};
 
 
 // List students (paginated)
@@ -51,10 +69,15 @@ router.get('/', async (req, res) => {
 
 // Get one student
 router.get('/:id', async (req, res) => {
+  const lookup = getStudentLookup(req.params.id);
+  if (!lookup) {
+    return res.status(400).json({ error: 'Invalid student id format' });
+  }
+
   try {
     const { rows } = await query(
-      `select ${STUDENT_COLUMNS} from students where id = $1`,
-      [req.params.id]
+      `select ${STUDENT_COLUMNS} from students where ${lookup.column} = $1`,
+      [lookup.value]
     );
     if (rows.length === 0) return res.status(404).json({ error: 'Not found' });
     res.json(rows[0]);
@@ -135,10 +158,65 @@ router.post('/batch', async (req, res) => {
   });
 });
 
+// Batch upload students from CSV
+router.post('/batch-upload', upload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'CSV file is required' });
+  }
+
+  const rows = [];
+
+  try {
+    await new Promise((resolve, reject) => {
+      Readable.from(req.file.buffer)
+        .pipe(csv())
+        .on('data', (row) => {
+          rows.push(row);
+        })
+        .on('end', resolve)
+        .on('error', reject);
+    });
+
+    let inserted = 0;
+
+    for (const row of rows) {
+      const lrn = row.LRN?.trim() || null;
+      const fullName = row.FullName?.trim();
+      const grade = row.Grade?.trim() || null;
+      const section = row.Section?.trim() || null;
+      const strand = row.Strand?.trim() || null;
+      const age = Number.parseInt(row.Age, 10);
+
+      if (!fullName) {
+        continue;
+      }
+
+      const { rowCount } = await query(
+        `insert into students (lrn, full_name, age, grade, section, strand)
+         values ($1, $2, $3, $4, $5, $6)
+         on conflict (lrn) do nothing`,
+        [lrn, fullName, Number.isNaN(age) ? null : age, grade, section, strand]
+      );
+
+      inserted += rowCount;
+    }
+
+    return res.json({ success: true, inserted });
+  } catch (error) {
+    console.error('Error in /api/students/batch-upload:', error);
+    return res.status(500).json({ error: 'Server error' });
+  }
+});
+
 // Update student
 router.put('/:id', async (req, res) => {
   // Removed legacy payload fields including last_name; update only current schema columns.
   const { lrn, full_name, grade, section, strand } = req.body ?? {};
+  const lookup = getStudentLookup(req.params.id);
+
+  if (!lookup) {
+    return res.status(400).json({ error: 'Invalid student id format' });
+  }
 
   try {
     const { rows } = await query(
@@ -148,9 +226,9 @@ router.put('/:id', async (req, res) => {
               grade = coalesce($3, grade),
               section = coalesce($4, section),
               strand = coalesce($5, strand)
-        where id = $6
+        where ${lookup.column} = $6
         returning ${STUDENT_COLUMNS}`,
-      [lrn ?? null, full_name ?? null, grade ?? null, section ?? null, strand ?? null, req.params.id]
+      [lrn ?? null, full_name ?? null, grade ?? null, section ?? null, strand ?? null, lookup.value]
     );
 
     if (rows.length === 0) return res.status(404).json({ error: 'Not found' });
@@ -164,8 +242,13 @@ router.put('/:id', async (req, res) => {
 });
 
 router.delete('/:id', async (req, res) => {
+  const lookup = getStudentLookup(req.params.id);
+  if (!lookup) {
+    return res.status(400).json({ error: 'Invalid student id format' });
+  }
+
   try {
-    const { rowCount } = await query('DELETE FROM students WHERE id = $1', [req.params.id]);
+    const { rowCount } = await query(`DELETE FROM students WHERE ${lookup.column} = $1`, [lookup.value]);
     if (rowCount === 0) return res.status(404).json({ error: 'Not found' });
 
     res.status(200).json({ message: 'Student deleted successfully.' });


### PR DESCRIPTION
### Motivation
- Prevent valid numeric student identifiers (e.g. `/api/students/123`) from being rejected as malformed and avoid letting non-UUID inputs reach Postgres and cause errors.
- Keep strict validation to reject truly malformed identifiers while supporting both `id` (UUID) and `student_id` (numeric) lookup styles used by the schema.

### Description
- Added `UUID_REGEX`, `NUMERIC_ID_REGEX`, and a `getStudentLookup(idParam)` helper to resolve an incoming `:id` to either `{ column: 'id', value: <uuid> }` or `{ column: 'student_id', value: <number> }` in `SDMS-backend/src/routes/students.js`.
- Replaced UUID-only guards in `GET /:id`, `PUT /:id`, and `DELETE /:id` with the lookup helper and updated the SQL to query by the resolved column/value.
- Included a CSV batch-upload route backed by `multer` and `csv-parser` for `POST /api/students/batch-upload`, and added `multer` and `csv-parser` entries to `SDMS-backend/package.json` for in-memory CSV parsing and insertions that use `ON CONFLICT (lrn) DO NOTHING`.

### Testing
- Performed a static syntax check with `node --check SDMS-backend/src/routes/students.js`, which succeeded.
- No automated integration or database tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe27b600c83209dac6af6a8d34e7a)